### PR TITLE
Update 3.platform.ingress.yaml

### DIFF
--- a/manifests/Policies/3.Platform/3.platform.ingress.yaml
+++ b/manifests/Policies/3.Platform/3.platform.ingress.yaml
@@ -26,7 +26,7 @@ spec:
       destination:
         namespaceSelector: >-
           projectcalico.org/name == "hipstershop" || projectcalico.org/name ==
-          "yaobank" || projectcalico.org/namespace == "bookinfo"
+          "yaobank" || projectcalico.org/name == "bookinfo"
     - action: Allow
       source: {}
       destination:


### PR DESCRIPTION
❗Issue: The field projectcalico.org/namespace is not valid — it should be projectcalico.org/name. (updated on line29)